### PR TITLE
Add elasticsearch version requirement to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ be self-explanatory.
 The next installation steps depend on if you want to use Elasticsearch or Algolia.
 
 ###Elasticsearch
-To use Elasticsearch you must install the official low level client:
+To use Elasticsearch you must install the official 1.x series low level client:
 ```bash
-composer require elasticsearch/elasticsearch
+composer require elasticsearch/elasticsearch "^1.3"
 ```
 
 You also should have a server with Elasticsearch installed.


### PR DESCRIPTION
According to issue #9 the `composer.json` was updated to make this clear. However, when following the readme directly it doesn't state which version to use, so 2.x is used by default when running the command provided which breaks things. This PR makes it clear to use the 1.x line of the elasticsearch php client without needing to read the `composer.json` file.
