### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpspec/phpspec": "^2.1",
-        "phpunit/phpunit" : "4.*",
+        "phpunit/phpunit" : "^4.8.36",
         "elasticsearch/elasticsearch": "^1.3",
         "algolia/algoliasearch-client-php": "^1.6"
     },

--- a/tests/Query/Algolia/SearchQueryTest.php
+++ b/tests/Query/Algolia/SearchQueryTest.php
@@ -3,9 +3,10 @@
 namespace Spatie\SearchIndex\Test\Query\Algolia;
 
 use DateTime;
+use PHPUnit\Framework\TestCase;
 use Spatie\SearchIndex\Query\Algolia\SearchQuery;
 
-class SearchQueryTest extends \PHPUnit_Framework_TestCase
+class SearchQueryTest extends TestCase
 {
     /**
      * @var SearchQuery


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.

I didn't update to `PHPUnit 5` 'cause this package still supports `PHP 5.5`.